### PR TITLE
Message Format

### DIFF
--- a/lib/m2pp.cpp
+++ b/lib/m2pp.cpp
@@ -32,10 +32,12 @@ void connection::reply_http(const request& req, const std::string& response, uin
 	}
 	httpresp << "\r\n" << response;
 
-	std::string msg = req.conn_id + " " + httpresp.str();
-
-	zmq::message_t outmsg(msg.length());
-	::memcpy(outmsg.data(), msg.data(), msg.length());
+	// Using the new mongrel2 format as of v1.3 
+	std::ostringstream msg;
+	msg << req.sender << " " << req.conn_id.size() << ":" << req.conn_id << ", " << httpresp.str();
+	std::string msg_str = msg.str();
+	zmq::message_t outmsg(msg_str.length());
+	::memcpy(outmsg.data(), msg_str.data(), msg_str.length());
 	resp.send(outmsg);
 }
 


### PR DESCRIPTION
Talked to Zed on IRC and he mentioned that the new message format now has a UUID before the conn_id as well as a few other changes to the first line, so I just made those changes in http_reply.

Cheers,
Curtis
