### PR TITLE
Fix Makefile for building test app on Ubuntu 11.04 and later.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX=g++
 CXXFLAGS=-ggdb -Wall -Wextra -Ilib
 LDFLAGS=-L/usr/local/lib -L.
-LIBS=-lzmq -ljson -lm2pp
+LIBS=-lm2pp -lzmq -ljson
 
 prefix=/usr/local
 incdir=$(prefix)/include


### PR DESCRIPTION
This fixes building on Ubuntu 11.04 and later. Ubuntu made the
--as-needed option default, so libzmq needs to appear after libm2pp.
Otherwise, 'uneeded' symbols will be discarded before the linker finds
that m2pp needs them.
