### PR TITLE
Websocket support

### DIFF
--- a/lib/m2pp.cpp
+++ b/lib/m2pp.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <sstream>
 #include <zmq.hpp>
+#include <assert.h>
 #include "m2pp.hpp"
 #include "m2pp_internal.hpp"
 
@@ -47,6 +48,33 @@ void connection::reply(const request& req, const std::string& response) {
 
 void connection::reply_websocket(const request& req, const std::string& response, char opcode, char rsvd) {
     reply(req, utils::websocket_header(response.size(), opcode, rsvd) + response);
+}
+
+void connection::deliver(const std::string& uuid, const std::vector<std::string>& idents, const std::string& data) {
+    assert(idents.size() <= MAX_IDENTS);
+	std::ostringstream msg;
+    msg << uuid << " ";
+
+    size_t idents_size(idents.size()-1); // initialize with size needed for spaces
+    for (size_t i=0; i<idents.size(); i++) {
+        idents_size += idents[i].size();
+    }
+	msg << idents_size << ":";
+    for (size_t i=0; i<idents.size(); i++) {
+        msg << idents[i];
+        if (i < idents.size()-1)
+            msg << " ";
+    }
+    msg << ", " << data;
+
+	std::string msg_str = msg.str();
+	zmq::message_t outmsg(msg_str.length());
+	::memcpy(outmsg.data(), msg_str.data(), msg_str.length());
+	resp.send(outmsg);
+}
+
+void connection::deliver_websocket(const std::string& uuid, const std::vector<std::string>& idents, const std::string& data, char opcode, char rsvd) {
+    deliver(uuid, idents, utils::websocket_header(data.size(), opcode, rsvd) + data);
 }
 
 request request::parse(zmq::message_t& msg) {

--- a/lib/m2pp.cpp
+++ b/lib/m2pp.cpp
@@ -32,9 +32,13 @@ void connection::reply_http(const request& req, const std::string& response, uin
 	}
 	httpresp << "\r\n" << response;
 
+    reply(req, httpresp.str());
+}
+
+void connection::reply(const request& req, const std::string& response) {
 	// Using the new mongrel2 format as of v1.3
 	std::ostringstream msg;
-	msg << req.sender << " " << req.conn_id.size() << ":" << req.conn_id << ", " << httpresp.str();
+	msg << req.sender << " " << req.conn_id.size() << ":" << req.conn_id << ", " << response;
 	std::string msg_str = msg.str();
 	zmq::message_t outmsg(msg_str.length());
 	::memcpy(outmsg.data(), msg_str.data(), msg_str.length());

--- a/lib/m2pp.cpp
+++ b/lib/m2pp.cpp
@@ -45,6 +45,10 @@ void connection::reply(const request& req, const std::string& response) {
 	resp.send(outmsg);
 }
 
+void connection::reply_websocket(const request& req, const std::string& response, char opcode, char rsvd) {
+    reply(req, utils::websocket_header(response.size(), opcode, rsvd) + response);
+}
+
 request request::parse(zmq::message_t& msg) {
 	request req;
 	std::string result(static_cast<const char *>(msg.data()), msg.size());

--- a/lib/m2pp.hpp
+++ b/lib/m2pp.hpp
@@ -9,6 +9,8 @@
 
 namespace m2pp {
 
+const size_t MAX_IDENTS(100);
+
 typedef std::pair<std::string, std::string> header;
 
 struct request {
@@ -29,6 +31,8 @@ class connection {
 		void reply(const request& req, const std::string& response);
 		void reply_http(const request& req, const std::string& response, uint16_t code = 200, const std::string& status = "OK", std::vector<header> hdrs = std::vector<header>());
         void reply_websocket(const request& req, const std::string& response, char opcode=1, char rsvd=0);
+        void deliver(const std::string& uuid, const std::vector<std::string>& idents, const std::string& data);
+        void deliver_websocket(const std::string& uuid, const std::vector<std::string>& idents, const std::string& data, char opcode=1, char rsvd=0);
 	private:
 		zmq::context_t ctx;
 		std::string sender_id;

--- a/lib/m2pp.hpp
+++ b/lib/m2pp.hpp
@@ -26,6 +26,7 @@ class connection {
 		connection(const std::string& sender_id_, const std::string& sub_addr_, const std::string& pub_addr_);
 		~connection();
 		request recv();
+		void reply(const request& req, const std::string& response);
 		void reply_http(const request& req, const std::string& response, uint16_t code = 200, const std::string& status = "OK", std::vector<header> hdrs = std::vector<header>());
 	private:
 		zmq::context_t ctx;

--- a/lib/m2pp.hpp
+++ b/lib/m2pp.hpp
@@ -28,6 +28,7 @@ class connection {
 		request recv();
 		void reply(const request& req, const std::string& response);
 		void reply_http(const request& req, const std::string& response, uint16_t code = 200, const std::string& status = "OK", std::vector<header> hdrs = std::vector<header>());
+        void reply_websocket(const request& req, const std::string& response, char opcode=1, char rsvd=0);
 	private:
 		zmq::context_t ctx;
 		std::string sender_id;

--- a/lib/m2pp_internal.hpp
+++ b/lib/m2pp_internal.hpp
@@ -8,6 +8,7 @@ namespace m2pp {
 		std::vector<std::string> split(const std::string& str, const std::string& sep, unsigned int count = 0);
 		std::string parse_netstring(const std::string& str, std::string& rest);
 		std::vector<header> parse_json(const std::string& jsondoc);
+        std::string websocket_header(size_t data_length, char opcode=1, char rsvd=0);
 
 	}
 

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -58,6 +58,33 @@ std::vector<header> parse_json(const std::string& jsondoc) {
 	return hdrs;
 }
 
+std::string websocket_header(size_t data_size, char opcode, char rsvd) {
+    std::ostringstream header;
+    header.put(0x80|opcode|rsvd<<4);
+    char dummyLength;
+    size_t realLength=data_size;
+    if (realLength < 126) {
+        dummyLength = static_cast<char>(realLength);
+    } else if (realLength < 1<<16) {
+        dummyLength = 126;
+    } else {
+        dummyLength = 127;
+    }
+    header.put(dummyLength);
+    if (dummyLength == 127) {
+        header.put(realLength >> 56 &0xff);
+        header.put(realLength >> 48 &0xff);
+        header.put(realLength >> 40 &0xff);
+        header.put(realLength >> 32 &0xff);
+        header.put(realLength >> 24 & 0xff);
+        header.put(realLength >> 16 & 0xff);
+    } if (dummyLength == 126 || dummyLength == 127) {
+        header.put(realLength >> 8 & 0xff);
+        header.put(realLength & 0xff);
+    }
+    return header.str();
+}
+
 }
 
 }


### PR DESCRIPTION
These commits port the following methods from the python API: reply, deliver, reply_websocket, deliver_websocket.
