### PR TITLE
Add missing header file and link against libjson-c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CXXFLAGS=-ggdb -Wall -Wextra -Ilib
 LDFLAGS=-L/usr/local/lib -L.
 LIBS=-lm2pp -lzmq -ljson-c
 
+prefix=/usr/local
 incdir=$(prefix)/include
 libdir=$(prefix)/lib
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX=g++
 CXXFLAGS=-ggdb -Wall -Wextra -Ilib
 LDFLAGS=-L/usr/local/lib -L.
-LIBS=-lm2pp -lzmq -ljson
+LIBS=-lm2pp -lzmq -ljson-c
 
 prefix=/usr/local
 incdir=$(prefix)/include

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ CXXFLAGS=-ggdb -Wall -Wextra -Ilib
 LDFLAGS=-L/usr/local/lib -L.
 LIBS=-lm2pp -lzmq -ljson-c
 
-prefix=/usr/local
 incdir=$(prefix)/include
 libdir=$(prefix)/lib
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This fork is an updated, working, cross-platform version of mongrel2-cpp library.
+
+
 mongrel2-cpp - a library to develop Mongrel2 handlers in C++
 ============================================================
 

--- a/cgi/m2pp-cgi.cpp
+++ b/cgi/m2pp-cgi.cpp
@@ -7,6 +7,7 @@
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <unistd.h>
 #include <m2pp.hpp>
 #include "m2pp-cgi.hpp"
 


### PR DESCRIPTION
- unistd.h is required in order to compile successfully. 
  m2pp-cgi.cpp calls fork, getopt and optarg.
- Link against libjson-c in order to work cross-platform.
