### PR TITLE
fixed deprecated ZMQ_UPSTREAM (now ZMQ_PULL), fixed missing unistd.h header

### DIFF
--- a/cgi/m2pp-cgi.cpp
+++ b/cgi/m2pp-cgi.cpp
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <cstring>
 #include <cstdlib>
+#include <unistd.h>
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/lib/m2pp.cpp
+++ b/lib/m2pp.cpp
@@ -8,7 +8,7 @@
 namespace m2pp {
 
 connection::connection(const std::string& sender_id_, const std::string& sub_addr_, const std::string& pub_addr_) 
-	: ctx(1), sender_id(sender_id_), sub_addr(sub_addr_), pub_addr(pub_addr_), reqs(ctx, ZMQ_UPSTREAM), resp(ctx, ZMQ_PUB) {
+	: ctx(1), sender_id(sender_id_), sub_addr(sub_addr_), pub_addr(pub_addr_), reqs(ctx, ZMQ_PULL), resp(ctx, ZMQ_PUB) {
 	reqs.connect(sub_addr.c_str());
 	resp.connect(pub_addr.c_str());
 	resp.setsockopt(ZMQ_IDENTITY, sender_id.data(), sender_id.length());


### PR DESCRIPTION
I'm trying to build m2cpp with latest zmq and found that ZMQ_UPSTREAM is deprecated. ZMQ_PULL should be used instead. The CGI implementation had a mssing unistd.h header (for ::getopt) on my system.
