### PR TITLE
Add connection.poll()

### DIFF
--- a/cgi/m2pp-cgi.cpp
+++ b/cgi/m2pp-cgi.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <signal.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <m2pp.hpp>

--- a/lib/m2pp.cpp
+++ b/lib/m2pp.cpp
@@ -1,4 +1,3 @@
-#include <poll.h>
 #include <string>
 #include <sstream>
 #include <zmq.hpp>

--- a/lib/m2pp.hpp
+++ b/lib/m2pp.hpp
@@ -6,9 +6,8 @@
 #include <utility>
 #include <zmq.hpp>
 #include <climits>
+#include <poll.h>
 #include <stdint.h>
-
-struct pollfd;
 
 namespace m2pp {
 

--- a/lib/m2pp.hpp
+++ b/lib/m2pp.hpp
@@ -5,7 +5,10 @@
 #include <vector>
 #include <utility>
 #include <zmq.hpp>
+#include <climits>
 #include <stdint.h>
+
+struct pollfd;
 
 namespace m2pp {
 
@@ -27,6 +30,7 @@ class connection {
 	public:
 		connection(const std::string& sender_id_, const std::string& sub_addr_, const std::string& pub_addr_);
 		~connection();
+		int poll(struct pollfd *pollfds, size_t pollfdsNum);
 		request recv();
 		void reply(const request& req, const std::string& response);
 		void reply_http(const request& req, const std::string& response, uint16_t code = 200, const std::string& status = "OK", std::vector<header> hdrs = std::vector<header>());


### PR DESCRIPTION
Previously there was no way for a single threaded program to be able to multiplex mongrel2 messages and data moving in or out of other file descriptors.  This new connection.poll() functionality supports that use case.

A return value of INT_MAX indicates that there is a message waiting on the mongrel2 zmq socket (they are always prioritized), otherwise it behaves like a regular poll().
