### PR TITLE
Get mongrel2-cpp working with the latest libzmq and libjson-c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX=g++
 CXXFLAGS=-ggdb -Wall -Wextra -Ilib
 LDFLAGS=-L/usr/local/lib -L.
-LIBS=-lm2pp -lzmq -ljson
+LIBS=-lm2pp -lzmq -ljson-c
 
 prefix=/usr/local
 incdir=$(prefix)/include

--- a/cgi/m2pp-cgi.cpp
+++ b/cgi/m2pp-cgi.cpp
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <cstring>
 #include <cstdlib>
+#include <unistd.h>
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/lib/m2pp.cpp
+++ b/lib/m2pp.cpp
@@ -8,7 +8,7 @@
 namespace m2pp {
 
 connection::connection(const std::string& sender_id_, const std::string& sub_addr_, const std::string& pub_addr_) 
-	: ctx(1), sender_id(sender_id_), sub_addr(sub_addr_), pub_addr(pub_addr_), reqs(ctx, ZMQ_UPSTREAM), resp(ctx, ZMQ_PUB) {
+	: ctx(1), sender_id(sender_id_), sub_addr(sub_addr_), pub_addr(pub_addr_), reqs(ctx, ZMQ_PULL), resp(ctx, ZMQ_PUB) {
 	reqs.connect(sub_addr.c_str());
 	resp.connect(pub_addr.c_str());
 	resp.setsockopt(ZMQ_IDENTITY, sender_id.data(), sender_id.length());

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -1,7 +1,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
-#include <json/json.h>
+#include <json-c/json.h>
 #include "m2pp.hpp"
 #include "m2pp_internal.hpp"
 


### PR DESCRIPTION
This patch will enable mongrel2-cpp to compile and work with the latest libzmq and libjson-c libraries.